### PR TITLE
feat: initialize workspace skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/liquidscope
+RUST_LOG=info,sqlx=warn
+HL_WS_URL=wss://<TODO-HYPERLIQUID-WS>
+BINANCE_WS_URL=wss://<TODO-BINANCE-WS>
+BYBIT_WS_URL=wss://<TODO-BYBIT-WS>
+TELEGRAM_WEBHOOK=https://api.telegram.org/bot<token>/sendMessage
+TELEGRAM_CHAT_ID=<chat_id>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,12 @@
+[workspace]
+members = [
+    "crates/storage",
+    "crates/ingest",
+    "crates/onchain",
+    "crates/analytics",
+    "crates/api",
+    "crates/alert",
+    "apps/api-server",
+    "apps/worker",
+]
+resolver = "2"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,38 @@
-# liquidation_Rust
-liquidation_Rust
+# LiquidScope-rs
+온체인+오프체인 선물거래 분석 플랫폼(MVP).
+
+```
+LiquidScope-rs
+├─ crates/
+│  ├─ storage      # DB 커넥터/리포지터리
+│  ├─ ingest       # 거래소 피드
+│  ├─ onchain      # EVM 인터페이스
+│  ├─ analytics    # 지표 계산
+│  ├─ api          # API 라우트
+│  └─ alert        # 웹훅 알림
+├─ apps/
+│  ├─ api-server   # API 서버 실행
+│  └─ worker       # 주기 태스크
+└─ migrations/     # SQL 스키마
+```
+
+## 빠른 시작
+
+```bash
+docker-compose up -d
+cp .env.example .env
+sqlx migrate run
+cargo run -p api-server
+```
+
+### 주요 엔드포인트
+- `GET /health`
+- `GET /spread?base=hyperliquid&ref=binance&symbol=BTCUSDT`
+- `GET /liq-risk?symbol=BTC-PERP`
+
+## 제한사항 / TODO
+- 실거래소 프로토콜 파서는 스텁 상태
+- 온체인 인덱싱은 기본 인터페이스만
+- 분석 로직은 최소한의 예시 구현
+
+![placeholder](assets/screenshot.png)

--- a/apps/api-server/Cargo.toml
+++ b/apps/api-server/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "api-server"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+api = { path = "../../crates/api" }
+storage = { path = "../../crates/storage" }
+dotenvy = "0.15"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
+tokio = { version = "1", features = ["full"] }
+axum = "0.7"
+anyhow = "1"

--- a/apps/api-server/src/main.rs
+++ b/apps/api-server/src/main.rs
@@ -1,0 +1,21 @@
+use axum::Server;
+use dotenvy::dotenv;
+use std::env;
+use tracing::info;
+use tracing_subscriber::EnvFilter;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    dotenv().ok();
+    tracing_subscriber::fmt().with_env_filter(EnvFilter::from_default_env()).init();
+
+    let db_url = env::var("DATABASE_URL").expect("DATABASE_URL not set");
+    let pool = storage::init_pool(&db_url).await?;
+    storage::migrate(&pool).await?;
+
+    let app = api::build_router(pool);
+    let addr = "0.0.0.0:3000".parse().unwrap();
+    info!("listening", %addr);
+    Server::bind(&addr).serve(app.into_make_service()).await?;
+    Ok(())
+}

--- a/apps/worker/Cargo.toml
+++ b/apps/worker/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "worker"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+analytics = { path = "../../crates/analytics" }
+storage = { path = "../../crates/storage" }
+ingest = { path = "../../crates/ingest" }
+alert = { path = "../../crates/alert" }
+dotenvy = "0.15"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
+tokio = { version = "1", features = ["full"] }
+anyhow = "1"

--- a/apps/worker/src/main.rs
+++ b/apps/worker/src/main.rs
@@ -1,0 +1,34 @@
+use dotenvy::dotenv;
+use std::env;
+use tokio::time::{interval, Duration};
+use tracing::info;
+use tracing_subscriber::EnvFilter;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    dotenv().ok();
+    tracing_subscriber::fmt().with_env_filter(EnvFilter::from_default_env()).init();
+
+    let db_url = env::var("DATABASE_URL").expect("DATABASE_URL not set");
+    let pool = storage::init_pool(&db_url).await?;
+    storage::migrate(&pool).await?;
+
+    let mut spread_iv = interval(Duration::from_secs(5));
+    let mut liq_iv = interval(Duration::from_secs(60));
+    let mut alert_iv = interval(Duration::from_secs(30));
+
+    loop {
+        tokio::select! {
+            _ = spread_iv.tick() => {
+                info!("spread snapshot tick");
+            }
+            _ = liq_iv.tick() => {
+                info!("liq risk refresh");
+            }
+            _ = alert_iv.tick() => {
+                let alerts = alert::evaluate_rules(&pool).await?;
+                for a in alerts { let _ = alert::send_alert("", &a).await; }
+            }
+        }
+    }
+}

--- a/crates/alert/Cargo.toml
+++ b/crates/alert/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "alert"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1"
+reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tracing = "0.1"
+storage = { path = "../storage" }

--- a/crates/alert/src/lib.rs
+++ b/crates/alert/src/lib.rs
@@ -1,0 +1,34 @@
+use anyhow::Result;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use tracing::info;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Alert {
+    pub title: String,
+    pub body: String,
+}
+
+pub async fn send_alert(webhook: &str, alert: &Alert) -> Result<()> {
+    let client = Client::new();
+    let payload = serde_json::json!({
+        "text": format!("{}\n{}", alert.title, alert.body)
+    });
+    client.post(webhook).json(&payload).send().await?;
+    Ok(())
+}
+
+pub async fn evaluate_rules(pool: &storage::PgPool) -> Result<Vec<Alert>> {
+    // TODO: 실제 규칙 평가 로직
+    let rows = sqlx::query!("SELECT rule_type, params FROM alert_rules WHERE enabled = true")
+        .fetch_all(pool)
+        .await?;
+    let alerts = rows
+        .into_iter()
+        .map(|r| Alert {
+            title: r.rule_type,
+            body: r.params.unwrap_or_default().to_string(),
+        })
+        .collect();
+    Ok(alerts)
+}

--- a/crates/analytics/Cargo.toml
+++ b/crates/analytics/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "analytics"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1"
+tracing = "0.1"
+serde = { version = "1", features = ["derive"] }
+statrs = "0.16"
+itertools = "0.12"
+serde_json = "1"
+storage = { path = "../storage" }

--- a/crates/analytics/src/lib.rs
+++ b/crates/analytics/src/lib.rs
@@ -1,0 +1,69 @@
+use serde::{Deserialize, Serialize};
+use tracing::info;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Position {
+    pub liq_price: f64,
+    pub size: f64,
+    pub leverage: f64,
+    pub wallet_balance_usd: f64,
+}
+
+pub fn calc_liq_risk(positions: &[Position], price: f64, bins: usize) -> (Vec<f64>, f64) {
+    let start = price * 0.5;
+    let end = price * 1.5;
+    let step = (end - start) / bins as f64;
+    let mut buckets = vec![0.0_f64; bins];
+    for p in positions {
+        let idx = ((p.liq_price - start) / step).floor() as isize;
+        if idx >= 0 && (idx as usize) < bins {
+            let weight = p.size.abs().min(p.wallet_balance_usd * p.leverage);
+            buckets[idx as usize] += weight;
+        }
+    }
+    let max = buckets.iter().cloned().fold(0.0, f64::max);
+    let total: f64 = buckets.iter().sum();
+    let index = if total == 0.0 { 0.0 } else { max / total * 100.0 };
+    (buckets, index)
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PnlAgg {
+    pub win_rate: f64,
+    pub sharpe: f64,
+    pub funding_ratio: f64,
+    pub avg_hold_secs: f64,
+}
+
+pub fn classify_trader(p: &PnlAgg) -> &'static str {
+    if p.win_rate >= 0.55 && p.sharpe >= 0.8 {
+        "Consistent"
+    } else if p.funding_ratio >= 0.3 {
+        "FundingFarmer"
+    } else if p.avg_hold_secs < 600.0 && p.win_rate < 0.4 {
+        "Gambler"
+    } else {
+        "Neutral"
+    }
+}
+
+pub fn calc_spread(base: f64, reference: f64) -> f64 {
+    (base - reference) / reference * 10_000.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_liq_risk_sum_and_norm() {
+        let positions = vec![
+            Position { liq_price: 90.0, size: 10.0, leverage: 2.0, wallet_balance_usd: 100.0 },
+            Position { liq_price: 110.0, size: 5.0, leverage: 3.0, wallet_balance_usd: 50.0 },
+        ];
+        let (buckets, idx) = calc_liq_risk(&positions, 100.0, 10);
+        let sum: f64 = buckets.iter().sum();
+        assert!(sum > 0.0);
+        assert!(idx >= 0.0 && idx <= 100.0);
+    }
+}

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "api"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+axum = { version = "0.7", features = ["macros", "json"] }
+anyhow = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tracing = "0.1"
+utoipa = { version = "4", features = ["axum"] }
+utoipa-swagger-ui = { version = "5", features = ["axum"] }
+storage = { path = "../storage" }
+analytics = { path = "../analytics" }
+alert = { path = "../alert" }
+sqlx = { version = "0.7", features = ["postgres", "runtime-tokio-rustls", "macros"] }
+
+tower = { version = "0.4", optional = false }

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -1,0 +1,110 @@
+use axum::{extract::State, routing::{get, post}, Json, Router};
+use serde::{Deserialize, Serialize};
+use storage::{self, PgPool};
+use analytics;
+use alert;
+use utoipa::{OpenApi, ToSchema};
+use utoipa_swagger_ui::SwaggerUi;
+
+#[derive(OpenApi)]
+#[openapi(paths(health, markets, spread, heatmap, liq_risk, pnl_rank, stable_metrics, create_alert),
+    components(schemas(SpreadQuery, SpreadResp, HeatmapQuery, LiqRiskQuery, NewAlert, Alert)))]
+struct ApiDoc;
+
+pub fn build_router(pool: PgPool) -> Router {
+    Router::new()
+        .route("/health", get(health))
+        .route("/markets", get(markets))
+        .route("/spread", get(spread))
+        .route("/heatmap", get(heatmap))
+        .route("/liq-risk", get(liq_risk))
+        .route("/pnl/rank", get(pnl_rank))
+        .route("/stable/metrics", get(stable_metrics))
+        .route("/alerts", post(create_alert))
+        .with_state(pool.clone())
+        .merge(SwaggerUi::new("/docs").url("/api-doc.json", ApiDoc::openapi()))
+}
+
+async fn health() -> &'static str {
+    "OK"
+}
+
+async fn markets(State(pool): State<PgPool>) -> Json<Vec<String>> {
+    let markets = storage::list_markets(&pool).await.unwrap_or_default();
+    Json(markets)
+}
+
+#[derive(Deserialize, ToSchema)]
+struct HeatmapQuery {
+    symbol: String,
+    bins: Option<usize>,
+}
+
+#[derive(Serialize, ToSchema)]
+struct HeatmapResp {
+    buckets: Vec<(f64, f64, i64)>,
+}
+
+async fn heatmap(_state: State<PgPool>, _q: axum::extract::Query<HeatmapQuery>) -> Json<HeatmapResp> {
+    Json(HeatmapResp { buckets: vec![] })
+}
+
+#[derive(Deserialize, ToSchema)]
+struct LiqRiskQuery {
+    symbol: String,
+}
+
+#[derive(Serialize, ToSchema)]
+struct LiqRiskResp {
+    index: f64,
+}
+
+async fn liq_risk(_state: State<PgPool>, _q: axum::extract::Query<LiqRiskQuery>) -> Json<LiqRiskResp> {
+    let positions = vec![];
+    let (_, idx) = analytics::calc_liq_risk(&positions, 0.0, 10);
+    Json(LiqRiskResp { index: idx })
+}
+
+#[derive(Deserialize, ToSchema)]
+struct SpreadQuery {
+    base: f64,
+    reference: f64,
+}
+
+#[derive(Serialize, ToSchema)]
+struct SpreadResp {
+    spread_bp: f64,
+}
+
+async fn spread(Query(q): axum::extract::Query<SpreadQuery>) -> Json<SpreadResp> {
+    let bp = analytics::calc_spread(q.base, q.reference);
+    Json(SpreadResp { spread_bp: bp })
+}
+
+async fn pnl_rank() -> Json<Vec<serde_json::Value>> {
+    Json(vec![])
+}
+
+async fn stable_metrics() -> Json<Vec<serde_json::Value>> {
+    Json(vec![])
+}
+
+#[derive(Deserialize, ToSchema)]
+struct NewAlert {
+    rule_type: String,
+    params: serde_json::Value,
+}
+
+#[derive(Serialize, ToSchema)]
+struct Alert {
+    id: i64,
+    rule_type: String,
+}
+
+async fn create_alert(
+    State(_pool): State<PgPool>,
+    Json(new): Json<NewAlert>,
+) -> Json<Alert> {
+    // TODO: DB에 저장
+    Json(Alert { id: 1, rule_type: new.rule_type })
+}

--- a/crates/api/tests/basic.rs
+++ b/crates/api/tests/basic.rs
@@ -1,0 +1,35 @@
+use api::build_router;
+use axum::{body::Body, http::{Request, StatusCode}};
+use storage;
+use tower::ServiceExt; // for `oneshot`
+
+#[tokio::test]
+async fn health_ok() {
+    let pool = sqlx::postgres::PgPoolOptions::new()
+        .connect_lazy("postgres://postgres:postgres@localhost:5432/liquidscope")
+        .expect("lazy pool");
+    let app = build_router(pool);
+    let resp = app
+        .oneshot(Request::builder().uri("/health").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn spread_endpoint() {
+    let pool = sqlx::postgres::PgPoolOptions::new()
+        .connect_lazy("postgres://postgres:postgres@localhost:5432/liquidscope")
+        .expect("lazy pool");
+    let app = build_router(pool);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/spread?base=100&reference=90")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}

--- a/crates/ingest/Cargo.toml
+++ b/crates/ingest/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "ingest"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+async-trait = "0.1"
+anyhow = "1"
+tracing = "0.1"
+tokio = { version = "1", features = ["full"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
+tokio-tungstenite = "0.20"
+futures = "0.3"
+storage = { path = "../storage" }

--- a/crates/ingest/src/lib.rs
+++ b/crates/ingest/src/lib.rs
@@ -1,0 +1,98 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
+use tracing::info;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct TradeEvent {
+    pub symbol: String,
+    pub price: f64,
+    pub qty: f64,
+    pub side: String,
+}
+
+#[async_trait]
+pub trait MarketFeed {
+    async fn stream_trades(&self, symbol: &str, tx: mpsc::Sender<TradeEvent>) -> Result<()>;
+    async fn latest_price(&self, symbol: &str) -> Result<f64>;
+}
+
+pub struct HyperliquidFeed {
+    pub ws_url: String,
+}
+
+impl HyperliquidFeed {
+    pub fn new(ws_url: String) -> Self {
+        Self { ws_url }
+    }
+}
+
+#[async_trait]
+impl MarketFeed for HyperliquidFeed {
+    async fn stream_trades(&self, symbol: &str, _tx: mpsc::Sender<TradeEvent>) -> Result<()> {
+        info!(?symbol, "stream_trades Hyperliquid stub");
+        Ok(()) // TODO: 실제 WS 연결
+    }
+    async fn latest_price(&self, _symbol: &str) -> Result<f64> {
+        Ok(0.0) // TODO: REST 호출
+    }
+}
+
+pub struct BinanceFeed {
+    pub ws_url: String,
+}
+
+impl BinanceFeed {
+    pub fn new(ws_url: String) -> Self {
+        Self { ws_url }
+    }
+}
+
+#[async_trait]
+impl MarketFeed for BinanceFeed {
+    async fn stream_trades(&self, symbol: &str, _tx: mpsc::Sender<TradeEvent>) -> Result<()> {
+        info!(?symbol, "stream_trades Binance stub");
+        Ok(())
+    }
+    async fn latest_price(&self, _symbol: &str) -> Result<f64> {
+        Ok(0.0)
+    }
+}
+
+pub struct BybitFeed {
+    pub ws_url: String,
+}
+
+impl BybitFeed {
+    pub fn new(ws_url: String) -> Self {
+        Self { ws_url }
+    }
+}
+
+#[async_trait]
+impl MarketFeed for BybitFeed {
+    async fn stream_trades(&self, symbol: &str, _tx: mpsc::Sender<TradeEvent>) -> Result<()> {
+        info!(?symbol, "stream_trades Bybit stub");
+        Ok(())
+    }
+    async fn latest_price(&self, _symbol: &str) -> Result<f64> {
+        Ok(0.0)
+    }
+}
+
+pub async fn consume_feed<F: MarketFeed + Send + Sync>(
+    feed: F,
+    symbol: &str,
+    pool: storage::PgPool,
+) -> Result<()> {
+    let (tx, mut rx) = mpsc::channel::<TradeEvent>(100);
+    let sym = symbol.to_string();
+    tokio::spawn(async move {
+        while let Some(evt) = rx.recv().await {
+            let _ = storage::insert_exchange(&pool, &evt.symbol).await; // placeholder
+            info!(?evt, "consumed trade event");
+        }
+    });
+    feed.stream_trades(&sym, tx).await
+}

--- a/crates/onchain/Cargo.toml
+++ b/crates/onchain/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "onchain"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1"
+async-trait = "0.1"
+tracing = "0.1"
+ethers = { version = "2", default-features = false, features = ["abigen", "tokio-runtime"] }
+serde = { version = "1", features = ["derive"] }

--- a/crates/onchain/src/lib.rs
+++ b/crates/onchain/src/lib.rs
@@ -1,0 +1,23 @@
+use anyhow::Result;
+use ethers::prelude::*;
+
+pub const STABLE_WHITELIST: [(&str, &str); 2] = [
+    ("USDT", "0xdAC17F958D2ee523a2206206994597C13D831ec7"),
+    ("USDC", "0xA0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"),
+];
+
+pub async fn get_erc20_balance(
+    provider: &Provider<Http>,
+    token_addr: Address,
+    owner: Address,
+) -> Result<U256> {
+    let erc20 = ethers::contract::abigen!(ERC20, "[function balanceOf(address) view returns (uint256)]");
+    let contract = ERC20::new(token_addr, provider.clone());
+    let balance = contract.balance_of(owner).call().await?;
+    Ok(balance)
+}
+
+/// TODO: 실제 Transfer 이벤트 스캔 구현
+pub async fn get_recent_transfers(_provider: &Provider<Http>, _token: Address) -> Result<Vec<()>> {
+    Ok(vec![])
+}

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "storage"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+sqlx = { version = "0.7", features = ["postgres", "runtime-tokio-rustls", "macros"] }
+anyhow = "1"
+async-trait = "0.1"
+tracing = "0.1"
+chrono = { version = "0.4", features = ["serde"] }
+uuid = { version = "1", features = ["serde", "v4"] }
+tokio = { version = "1", features = ["full"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -1,0 +1,53 @@
+use anyhow::Result;
+use sqlx::postgres::PgPoolOptions;
+pub use sqlx::PgPool;
+use tracing::info;
+
+pub async fn init_pool(database_url: &str) -> Result<PgPool> {
+    let pool = PgPoolOptions::new()
+        .max_connections(5)
+        .connect(database_url)
+        .await?;
+    Ok(pool)
+}
+
+pub async fn migrate(pool: &PgPool) -> Result<()> {
+    info!("running migrations");
+    sqlx::migrate!("../../migrations").run(pool).await?;
+    Ok(())
+}
+
+#[derive(sqlx::FromRow, serde::Serialize, serde::Deserialize, Debug)]
+pub struct Exchange {
+    pub id: i32,
+    pub name: String,
+}
+
+pub async fn insert_exchange(pool: &PgPool, name: &str) -> Result<Exchange> {
+    let rec = sqlx::query_as::<_, Exchange>(
+        "INSERT INTO exchanges (name) VALUES ($1) RETURNING id, name",
+    )
+    .bind(name)
+    .fetch_one(pool)
+    .await?;
+    Ok(rec)
+}
+
+pub async fn list_markets(pool: &PgPool) -> Result<Vec<String>> {
+    let rows = sqlx::query!("SELECT symbol FROM markets")
+        .fetch_all(pool)
+        .await?;
+    Ok(rows.into_iter().map(|r| r.symbol).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[sqlx::test(migrations = "../../migrations")]
+    async fn test_insert_exchange(pool: PgPool) -> Result<()> {
+        let ex = insert_exchange(&pool, "hyperliquid").await?;
+        assert_eq!(ex.name, "hyperliquid");
+        Ok(())
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: liquidscope
+    ports:
+      - "5432:5432"
+  adminer:
+    image: adminer
+    ports:
+      - "8080:8080"
+    depends_on:
+      - db

--- a/migrations/0001_init.sql
+++ b/migrations/0001_init.sql
@@ -1,0 +1,103 @@
+CREATE TABLE exchanges (
+  id SERIAL PRIMARY KEY,
+  name TEXT UNIQUE NOT NULL
+);
+
+CREATE TABLE markets (
+  id SERIAL PRIMARY KEY,
+  symbol TEXT NOT NULL,
+  exchange_id INT NOT NULL REFERENCES exchanges(id),
+  UNIQUE (exchange_id, symbol)
+);
+
+CREATE TABLE trades (
+  id BIGSERIAL PRIMARY KEY,
+  ts TIMESTAMPTZ NOT NULL,
+  market_id INT NOT NULL REFERENCES markets(id),
+  price DOUBLE PRECISION NOT NULL,
+  qty DOUBLE PRECISION NOT NULL,
+  side TEXT NOT NULL,
+  buyer_addr TEXT,
+  seller_addr TEXT
+);
+
+CREATE TABLE tracked_wallets (
+  addr TEXT PRIMARY KEY,
+  first_seen TIMESTAMPTZ NOT NULL DEFAULT now(),
+  labels TEXT[] DEFAULT '{}',
+  note TEXT
+);
+
+CREATE TABLE positions (
+  id BIGSERIAL PRIMARY KEY,
+  addr TEXT NOT NULL REFERENCES tracked_wallets(addr),
+  market_id INT NOT NULL REFERENCES markets(id),
+  ts TIMESTAMPTZ NOT NULL,
+  entry_price DOUBLE PRECISION,
+  liq_price DOUBLE PRECISION,
+  take_profit DOUBLE PRECISION,
+  leverage DOUBLE PRECISION,
+  size DOUBLE PRECISION,
+  wallet_balance_usd DOUBLE PRECISION
+);
+
+CREATE INDEX ON positions (market_id, ts);
+CREATE INDEX ON positions (addr);
+
+CREATE TABLE pnl_agg (
+  id BIGSERIAL PRIMARY KEY,
+  addr TEXT NOT NULL REFERENCES tracked_wallets(addr),
+  market_id INT NOT NULL REFERENCES markets(id),
+  bucket DATE NOT NULL,
+  realized DOUBLE PRECISION,
+  unrealized DOUBLE PRECISION,
+  win_rate DOUBLE PRECISION,
+  sharpe DOUBLE PRECISION
+);
+
+CREATE UNIQUE INDEX ON pnl_agg (addr, market_id, bucket);
+
+CREATE TABLE liq_heatmap (
+  id BIGSERIAL PRIMARY KEY,
+  market_id INT NOT NULL REFERENCES markets(id),
+  bucket_start DOUBLE PRECISION NOT NULL,
+  bucket_end DOUBLE PRECISION NOT NULL,
+  count BIGINT NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX ON liq_heatmap (market_id, bucket_start, bucket_end);
+
+CREATE TABLE spread_snapshots (
+  id BIGSERIAL PRIMARY KEY,
+  ts TIMESTAMPTZ NOT NULL,
+  base_market_id INT NOT NULL REFERENCES markets(id),
+  ref_market_id INT NOT NULL REFERENCES markets(id),
+  base_price DOUBLE PRECISION NOT NULL,
+  ref_price DOUBLE PRECISION NOT NULL,
+  spread_bp DOUBLE PRECISION NOT NULL
+);
+
+CREATE INDEX ON spread_snapshots (ts);
+
+CREATE TABLE stable_metrics (
+  id BIGSERIAL PRIMARY KEY,
+  ts TIMESTAMPTZ NOT NULL,
+  stable_symbol TEXT NOT NULL,
+  net_mint_burn DOUBLE PRECISION,
+  exchange_netflow_usd DOUBLE PRECISION
+);
+
+CREATE TABLE alert_rules (
+  id SERIAL PRIMARY KEY,
+  rule_type TEXT NOT NULL,
+  params JSONB NOT NULL,
+  enabled BOOLEAN NOT NULL DEFAULT true
+);
+
+CREATE TABLE alert_logs (
+  id BIGSERIAL PRIMARY KEY,
+  rule_id INT REFERENCES alert_rules(id),
+  ts TIMESTAMPTZ NOT NULL DEFAULT now(),
+  payload JSONB
+);


### PR DESCRIPTION
## Summary
- 프로젝트 워크스페이스와 6개 크레이트, 2개 앱 기본 구조 추가
- PostgreSQL 마이그레이션 및 .env, docker-compose 설정
- API 라우트/워커 태스크/분석 로직 스텁 작성

## Testing
- `cargo build` *(네트워크 403으로 실패)*
- `cargo test` *(네트워크 403으로 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68af345483788325a0bb6d5cf70c67de